### PR TITLE
Update to pick team

### DIFF
--- a/src/OpenFPL_frontend/src/lib/components/homepage/homepage-gameweek-panel.svelte
+++ b/src/OpenFPL_frontend/src/lib/components/homepage/homepage-gameweek-panel.svelte
@@ -2,7 +2,7 @@
     import { onMount } from "svelte";
     import { managerStore } from "$lib/stores/manager-store";
     import { leagueStore } from "$lib/stores/league-store";
-    import { formatWholeE8s } from "$lib/utils/helpers";
+    import { formatWholeE8s } from "$lib/utils/Helpers";
     import HeaderContentPanel from "../shared/panels/header-content-panel.svelte";
     import { rewardRatesStore } from "$lib/stores/reward-pool-store";
 

--- a/src/OpenFPL_frontend/src/lib/components/pick-team/desktop-buttons.svelte
+++ b/src/OpenFPL_frontend/src/lib/components/pick-team/desktop-buttons.svelte
@@ -14,11 +14,18 @@
     export let playTransferWindow : () => void;
     export let autoFillFantasyTeam : () => void;
     export let saveFantasyTeam : () => void;
+    export let handleResetTeam: () => void;
+    export let startingFantasyTeam: TeamSelectionDTO;
     
+    $: showResetButton = $fantasyTeam?.playerIds && startingFantasyTeam?.playerIds && (
+      (startingFantasyTeam.playerIds.filter(id => id > 0).length === 11 && 
+       $fantasyTeam.playerIds.filter(id => id > 0).length < startingFantasyTeam.playerIds.filter(id => id > 0).length) ||
+      !$fantasyTeam.playerIds.every((id, index) => id === startingFantasyTeam.playerIds[index])
+    );
 </script>
-<div class="flex flex-row justify-between items-center text-white bg-panel p-2 rounded-md w-full mb-4">
+<div class="flex flex-row items-center justify-between w-full p-2 mb-4 text-white rounded-md bg-panel">
       
-    <div class="flex flex-row justify-between md:justify-start flex-grow ml-4">
+    <div class="flex flex-row justify-between flex-grow ml-4 md:justify-start">
       <button class={`btn ${ $pitchViewActive ? `fpl-button` : `inactive-btn` } tab-switcher-label rounded-l-md`} on:click={showPitchView}>
         Pitch View
       </button>
@@ -27,10 +34,10 @@
       </button>
     </div>
 
-    <div class="text-center md:text-left w-full mt-0 md:ml-8 order-2 mt-4 md:mt-0">
+    <div class="order-2 w-full mt-0 mt-4 text-center md:text-left md:ml-8 md:mt-0">
       <span class="text-lg">
         Formation:
-        <select class="px-4 py-2 border-sm fpl-dropdown text-center" bind:value={$selectedFormation}>
+        <select class="px-4 py-2 text-center border-sm fpl-dropdown" bind:value={$selectedFormation}>
           {#each $availableFormations as formation}
             <option value={formation}>{formation}</option>
           {/each}
@@ -38,7 +45,7 @@
       </span>
     </div>
 
-    <div class="flex flex-col md:flex-row w-full md:justify-end gap-4 mr-0 md:mr-4 order-1 md:order-3 mt-2 md:mt-0">
+    <div class="flex flex-col order-1 w-full gap-4 mt-2 mr-0 md:flex-row md:justify-end md:mr-4 md:order-3 md:mt-0">
       {#if $leagueStore!.transferWindowActive && $leagueStore!.seasonActive && $leagueStore!.activeMonth == 1}
         <button
           disabled={$transferWindowPlayed}
@@ -60,17 +67,25 @@
           ${
             $fantasyTeam?.playerIds &&
             $fantasyTeam?.playerIds.filter((x) => x === 0).length > 0
-              ? "bg-BrandPurple"
+              ? "bg-BrandPurple hover:bg-BrandPurple/90"
               : "bg-gray-500"
           } text-white min-w-[125px]`}
       >
         Auto Fill
       </button>
+      {#if showResetButton}
+        <button
+          on:click={handleResetTeam}
+          class="btn w-full md:w-auto px-4 py-2 rounded bg-BrandRed hover:bg-BrandRed/90 text-white min-w-[125px]"
+        >
+          Reset Team
+        </button>
+      {/if}
       <button
         disabled={!$isSaveButtonActive}
         on:click={saveFantasyTeam}
         class={`btn w-full md:w-auto px-4 py-2 rounded ${
-          $isSaveButtonActive ? "bg-BrandPurple" : "bg-gray-500"
+          $isSaveButtonActive ? "bg-BrandPurple hover:bg-BrandPurple/90" : "bg-gray-500"
         } text-white min-w-[125px]`}
       >
         Save Team

--- a/src/OpenFPL_frontend/src/lib/components/pick-team/mobile-buttons.svelte
+++ b/src/OpenFPL_frontend/src/lib/components/pick-team/mobile-buttons.svelte
@@ -14,9 +14,16 @@
     export let playTransferWindow : () => void;
     export let autoFillFantasyTeam : () => void;
     export let saveFantasyTeam : () => void;
+    export let handleResetTeam: () => void;
+    export let startingFantasyTeam: TeamSelectionDTO;
     
+    $: showResetButton = $fantasyTeam?.playerIds && startingFantasyTeam?.playerIds && (
+      (startingFantasyTeam.playerIds.filter(id => id > 0).length === 11 && 
+       $fantasyTeam.playerIds.filter(id => id > 0).length < startingFantasyTeam.playerIds.filter(id => id > 0).length) ||
+      !$fantasyTeam.playerIds.every((id, index) => id === startingFantasyTeam.playerIds[index])
+    );   
 </script>
-<div class="bg-panel xs:flex flex-row">
+<div class="flex-row bg-panel xs:flex">
     <div class="w-full xs:w-1/2">
       <div class="flex flex-row ml-4" style="margin-top: 2px;">
         <button
@@ -41,7 +48,7 @@
       <div class="flex flex-row items-center mx-4 mt-3">
         <p class="mr-2">Formation:</p>
         <select
-          class="px-4 xs:mb-1 border-sm fpl-dropdown text-center text-center w-full"
+          class="w-full px-4 text-center xs:mb-1 border-sm fpl-dropdown"
           bind:value={$selectedFormation}
         >
           {#each $availableFormations as formation}
@@ -65,6 +72,14 @@
         >
           Auto Fill
         </button>
+        {#if showResetButton}
+          <button
+            on:click={handleResetTeam}
+            class="side-button-base bg-BrandRed"
+          >
+            Reset Team
+          </button>
+        {/if}
         <button
           disabled={!$isSaveButtonActive}
           on:click={saveFantasyTeam}
@@ -76,7 +91,7 @@
         </button>
       </div>
       {#if $leagueStore!.transferWindowActive && $leagueStore!.seasonActive && $leagueStore!.activeMonth == 1}
-        <div class="flex flex-row mx-4 space-x-1 mb-4">
+        <div class="flex flex-row mx-4 mb-4 space-x-1">
           <button
             disabled={$transferWindowPlayed}
             on:click={playTransferWindow}

--- a/src/OpenFPL_frontend/src/lib/components/pick-team/pick-team-players.svelte
+++ b/src/OpenFPL_frontend/src/lib/components/pick-team/pick-team-players.svelte
@@ -5,20 +5,20 @@
   import { leagueStore } from "$lib/stores/league-store";
   import { playerStore } from "$lib/stores/player-store";
   import { canAddPlayerToCurrentFormation, findValidFormationWithPlayer, getAvailablePositionIndex, getHighestValuedPlayerId, getTeamFormation, repositionPlayersForNewFormation } from "$lib/utils/pick-team.helpers";
-  import type { PlayerDTO } from "../../../../../declarations/data_canister/data_canister.did";
+  import type { PlayerDTO, TeamSelectionDTO } from "../../../../../declarations/OpenFPL_backend/OpenFPL_backend.did";
 
   import ConfirmCaptainChange from "./modals/confirm-captain-change-modal.svelte";
   import AddPlayerModal from "./modals/add-player-modal.svelte";
   import WidgetSpinner from "../shared/widget-spinner.svelte";
   import SelectedPlayersPitch from "./selected-players-pitch.svelte";
   import SelectedPlayersList from "./selected-players-list.svelte";
-  import { convertPositionToIndex } from "$lib/utils/helpers";
-    import type { TeamSelectionDTO } from "../../../../../declarations/OpenFPL_backend/OpenFPL_backend.did";
+  import { convertPositionToIndex } from "$lib/utils/Helpers";
   
   export let fantasyTeam: Writable<TeamSelectionDTO | undefined>;
   export let pitchView: Writable<boolean>;
   export let selectedFormation: Writable<string>;
   export let teamValue: Writable<number>;
+  export let sessionAddedPlayers: Writable<number[]>;
 
   let isLoading = true;
   let showAddPlayerModal = false;
@@ -27,9 +27,10 @@
   let selectedPosition = writable(-1);
   let selectedColumn = -1;
   let canSellPlayer = writable(true);
-  let sessionAddedPlayers = writable<number[]>([]);
   let newCaptainId = writable<number>(0);
   let newCaptain = writable<string>("");
+  let positionsChanged = new Set<number>();
+  let startingTeamPlayerIds: number[] = [];
 
   onMount(async () => {
     const storedViewMode = localStorage.getItem("viewMode");
@@ -38,6 +39,9 @@
       }
       await loadData();
       isLoading = false;
+      if ($fantasyTeam) {
+        startingTeamPlayerIds = Array.from($fantasyTeam.playerIds);
+      }
   });
 
   async function loadData() {
@@ -98,30 +102,31 @@
           return currentTeam;
         }
 
-        const newPlayerIds = Uint16Array.from(currentTeam!.playerIds);
-        newPlayerIds[playerIndex] = 0;
+      const newPlayerIds = Uint16Array.from(currentTeam!.playerIds);
+      newPlayerIds[playerIndex] = 0;
 
-        let transfersAvailable = $fantasyTeam.transfersAvailable;
-
-        if ($sessionAddedPlayers.includes(playerId)) {
-          if (!newTeam && $leagueStore!.activeGameweek == 0 ? $leagueStore!.unplayedGameweek : $leagueStore!.activeGameweek > 1) {
-            transfersAvailable += 1;
-          }
-          $sessionAddedPlayers = $sessionAddedPlayers.filter((id) => id !== playerId);
+      let transfersAvailable = currentTeam!.transfersAvailable;
+      
+      if ($sessionAddedPlayers.includes(playerId)) {
+        if (!currentTeam!.firstGameweek && currentTeam!.transferWindowGameweek !== $leagueStore!.unplayedGameweek) {
+          transfersAvailable += 1;
         }
+        $sessionAddedPlayers = $sessionAddedPlayers.filter((id) => id !== playerId);
+        positionsChanged.delete(playerIndex); 
+      }
 
-        let newTeamValue = 0;
-        newPlayerIds.forEach((id) => {
-          const player = $playerStore.find((p) => p.id === id);
-          if (player) {
-            newTeamValue += player.valueQuarterMillions;
-          }
-        });
-        teamValue.set(newTeamValue / 4);
-        
-        let bankQuarterMillions = $fantasyTeam.bankQuarterMillions + $playerStore.find((x) => x.id === playerId)!.valueQuarterMillions;
-        return { ...currentTeam!, playerIds: newPlayerIds, bankQuarterMillions, transfersAvailable, teamValue };
-      })
+      let newTeamValue = 0;
+      newPlayerIds.forEach((id) => {
+        const player = $playerStore.find((p) => p.id === id);
+        if (player) {
+          newTeamValue += player.valueQuarterMillions;
+        }
+      });
+      teamValue.set(newTeamValue / 4);
+      
+      let bankQuarterMillions = $fantasyTeam.bankQuarterMillions + $playerStore.find((x) => x.id === playerId)!.valueQuarterMillions;
+      return { ...currentTeam!, playerIds: newPlayerIds, bankQuarterMillions, transfersAvailable, teamValue };
+    })
   }
 
   $: if ($fantasyTeam) {
@@ -194,6 +199,15 @@
       if (indexToAdd < newPlayerIds.length) {
         newPlayerIds[indexToAdd] = player.id;
 
+        let transfersAvailable = currentTeam!.transfersAvailable;
+        if (!positionsChanged.has(indexToAdd) && 
+            !currentTeam!.firstGameweek && 
+            currentTeam!.transferWindowGameweek !== $leagueStore!.unplayedGameweek &&
+            !startingTeamPlayerIds.includes(player.id)) {
+          transfersAvailable -= 1;
+          positionsChanged.add(indexToAdd);
+        }
+
         let newTeamValue = 0;
         newPlayerIds.forEach((id) => {
           const player = $playerStore.find((p) => p.id === id);
@@ -205,8 +219,6 @@
 
         let bankQuarterMillions = currentTeam!.bankQuarterMillions - player.valueQuarterMillions;
       
-        let transfersAvailable = currentTeam!.transfersAvailable - 1;
-
         return { ...currentTeam!, playerIds: newPlayerIds, teamValue, bankQuarterMillions, transfersAvailable };
       } else {
         console.error(

--- a/src/OpenFPL_frontend/src/lib/components/simple-fixtures.svelte
+++ b/src/OpenFPL_frontend/src/lib/components/simple-fixtures.svelte
@@ -4,7 +4,7 @@
   import { fixtureStore } from "$lib/stores/fixture-store";
   import BadgeIcon from "$lib/icons/BadgeIcon.svelte";
   import type { FixtureWithTeams } from "$lib/types/fixture-with-teams";
-  import { convertFixtureStatus, formatUnixTimeToTime, getFixturesWithTeams, getGameweeks, reduceFilteredFixtures } from "../utils/helpers";
+  import { convertFixtureStatus, formatUnixTimeToTime, getFixturesWithTeams, getGameweeks, reduceFilteredFixtures } from "../utils/Helpers";
   import { storeManager } from "$lib/managers/store-manager";
   import { leagueStore } from "$lib/stores/league-store";
   import GameweekFilter from "./shared/filters/gameweek-filter.svelte";
@@ -34,30 +34,30 @@
 <div class="bg-panel">
   <div>
     <div class="flex items-center justify-between py-2 bg-light-gray">
-      <h1 class="mx-4 m-2 side-panel-header">Fixtures</h1>
+      <h1 class="m-2 mx-4 side-panel-header">Fixtures</h1>
     </div>
     <GameweekFilter {selectedGameweek} {gameweeks} {changeGameweek} />
     <div>
       {#each Object.entries(groupedFixtures) as [date, fixtures]}
-        <div class="flex items-center justify-between border-b border-gray-700 py-2 bg-light-gray">
+        <div class="flex items-center justify-between py-2 border-b border-gray-700 bg-light-gray">
           <h2 class="ml-4">{date}</h2>
         </div>
         {#each fixtures as { fixture, homeTeam, awayTeam }}
           <div class={`flex items-center justify-between py-2 border-b border-gray-700
               ${ convertFixtureStatus(fixture.status) < 3 ? "text-gray-400" : "text-white" }`}
           >
-            <div class="flex w-full items-center space-x-10 mx-4 xs:mx-8">
+            <div class="flex items-center w-full mx-4 space-x-10 xs:mx-8">
               <div class="flex flex-col w-3/6 min-w-[100px] md:min-w-[200px]">
-                <a class="my-1 flex items-center" href={`/club?id=${fixture.homeClubId}`}>
+                <a class="flex items-center my-1" href={`/club?id=${fixture.homeClubId}`}>
                   <BadgeIcon club={homeTeam!} className="w-4 mr-1" />
                   {homeTeam ? homeTeam.friendlyName : ""}
                 </a>
-                <a class="my-1 flex items-center" href={`/club?id=${fixture.awayClubId}`}>
+                <a class="flex items-center my-1" href={`/club?id=${fixture.awayClubId}`}>
                   <BadgeIcon club={awayTeam!} className="w-4 mr-1" />
                   {awayTeam ? awayTeam.friendlyName : ""}
                 </a>
               </div>
-              <div class="flex flex-col w-1/6 items-center justify-center">
+              <div class="flex flex-col items-center justify-center w-1/6">
                 <span>{convertFixtureStatus(fixture.status) < 3 ? "-" : fixture.homeGoals}</span>
                 <span>{convertFixtureStatus(fixture.status) < 3 ? "-" : fixture.awayGoals}</span>
               </div>

--- a/src/OpenFPL_frontend/src/lib/stores/manager-store.ts
+++ b/src/OpenFPL_frontend/src/lib/stores/manager-store.ts
@@ -53,7 +53,7 @@ function createManagerStore() {
     captainId: 0,
     monthlyBonusesAvailable: 0,
     canisterId: "",
-    firstGameweek: false,
+    firstGameweek: true,
   };
 
   async function getPublicProfile(

--- a/src/OpenFPL_frontend/src/lib/types/league-status.ts
+++ b/src/OpenFPL_frontend/src/lib/types/league-status.ts
@@ -1,0 +1,15 @@
+export type LeagueStatus = {
+    activeGameweek: number;
+    activeMonth: number;
+    activeSeasonId: number;
+    completedGameweek: number;
+    leagueId: number;
+    seasonActive: boolean;
+    totalGameweeks: number;
+    transferWindowActive: true;
+    transferWindowEndDay: number;
+    transferWindowEndMonth: number;
+    transferWindowStartDay: number;
+    transferWindowStartMonth: number;
+    unplayedGameweek: number;
+}

--- a/src/OpenFPL_frontend/src/lib/utils/Helpers.ts
+++ b/src/OpenFPL_frontend/src/lib/utils/Helpers.ts
@@ -3,16 +3,19 @@ import type { TeamStats } from "$lib/types/team-stats";
 import * as FlagIcons from "svelte-flag-icons";
 import type {
   ClubDTO,
-  PlayerDTO,
   PlayerPointsDTO,
   FixtureDTO,
   FixtureStatusType,
   PlayerEventType,
   PlayerPosition,
-  FantasyTeamSnapshot,
-  LeaderboardEntry,
+} from "../../../../declarations/data_canister/data_canister.did";
+import type {
+  PlayerDTO,
+  ManagerGameweekDTO,
+  LeaderboardEntryDTO,
   RewardEntry,
 } from "../../../../declarations/OpenFPL_backend/OpenFPL_backend.did";
+
 import type { GameweekData } from "$lib/interfaces/GameweekData";
 import EnglandFlag from "../flags/england.svelte"; // Custom Svelte component for England
 import ScotlandFlag from "../flags/scotland.svelte"; // Custom Svelte component for Scotland
@@ -1102,12 +1105,13 @@ export function getActualIndex(
   return startIndex + colIndex;
 }
 
-export function reduceFilteredFixtures(filteredFixtures: FixtureWithClubs[]): {
-  [key: string]: FixtureWithClubs[];
+export function reduceFilteredFixtures(filteredFixtures: FixtureWithTeams[]): {
+  [key: string]: FixtureWithTeams[];
 } {
   return filteredFixtures.reduce(
-    (acc: { [key: string]: FixtureWithClubs[] }, fixtureWithTeams) => {
-      const date = new Date(Number(fixtureWithTeams.kickOff) / 1000000);
+    (acc: { [key: string]: FixtureWithTeams[] }, fixture) => {
+      const kickOff = fixture.fixture.kickOff;
+      const date = new Date(Number(kickOff) / 1000000);
       const dateFormatter = new Intl.DateTimeFormat("en-GB", {
         weekday: "long",
         day: "numeric",
@@ -1119,10 +1123,10 @@ export function reduceFilteredFixtures(filteredFixtures: FixtureWithClubs[]): {
       if (!acc[dateKey]) {
         acc[dateKey] = [];
       }
-      acc[dateKey].push(fixtureWithTeams);
+      acc[dateKey].push(fixture);
       return acc;
     },
-    {} as { [key: string]: FixtureWithClubs[] },
+    {} as { [key: string]: FixtureWithTeams[] },
   );
 }
 
@@ -1148,7 +1152,7 @@ export function convertToE8s(amount: string): bigint {
   return BigInt(whole) * 100_000_000n + BigInt(fractionPadded);
 }
 
-export function getBonusIcon(snapshot: FantasyTeamSnapshot): string {
+export function getBonusIcon(snapshot: ManagerGameweekDTO): string {
   if (snapshot.goalGetterGameweek === snapshot.gameweek) {
     return `<img src="/goal-getter.png" alt="Bonus" class="w-6 md:w-9" />`;
   } else if (snapshot.passMasterGameweek === snapshot.gameweek) {
@@ -1175,9 +1179,9 @@ export function getBonusIcon(snapshot: FantasyTeamSnapshot): string {
 }
 
 export function mergeLeaderboardWithRewards(
-  leaderboardEntries: LeaderboardEntry[],
+  leaderboardEntries: LeaderboardEntryDTO[],
   rewards: RewardEntry[],
-): LeaderboardEntry[] {
+): LeaderboardEntryDTO[] {
   const rewardMap = new Map(
     rewards.map((reward) => [reward.principalId, reward.amount]),
   );

--- a/src/OpenFPL_frontend/src/routes/pick-team/+page.svelte
+++ b/src/OpenFPL_frontend/src/routes/pick-team/+page.svelte
@@ -5,7 +5,7 @@
   import { storeManager } from "$lib/managers/store-manager";
   import { managerStore } from "$lib/stores/manager-store";
   import { appStore } from "$lib/stores/app-store";
-  import type { PickTeamDTO } from "../../../../declarations/OpenFPL_backend/OpenFPL_backend.did";
+  import type { TeamSelectionDTO } from "../../../../declarations/OpenFPL_backend/OpenFPL_backend.did";
   import { allFormations } from "$lib/utils/pick-team.helpers";
   
   import Layout from "../Layout.svelte";
@@ -17,11 +17,12 @@
   import BonusPanel from "$lib/components/pick-team/bonus-panel.svelte";
   import OnHold from "$lib/components/pick-team/on-hold.svelte";
     
-  let fantasyTeam = writable<PickTeamDTO | undefined>(undefined);
+  let fantasyTeam = writable<TeamSelectionDTO | undefined>(undefined);
   let availableFormations = writable(Object.keys(allFormations));   
   let selectedFormation = writable('4-4-2');
   let teamValue = writable(0);
   const pitchView = writable(true);
+  let sessionAddedPlayers = writable<number[]>([]);
   
   let isLoading = true;
   
@@ -66,10 +67,17 @@
     {:else}
     <div>
       <PickTeamHeader {fantasyTeam} {teamValue} />
-      <PickTeamButtons {fantasyTeam} {pitchView} {selectedFormation} {availableFormations} />
-      <div class="flex flex-col xl:flex-row mt-2 xl:mt-0">
-        <PickTeamPlayers {fantasyTeam} {pitchView} {selectedFormation} {teamValue} />
-        <div class="hidden xl:flex w-full xl:w-1/2 ml-2">
+      <PickTeamButtons 
+        {fantasyTeam} 
+        {pitchView} 
+        {selectedFormation} 
+        {availableFormations}
+        {teamValue}
+        {sessionAddedPlayers}
+      />
+      <div class="flex flex-col mt-2 xl:flex-row xl:mt-0">
+        <PickTeamPlayers {fantasyTeam} {pitchView} {selectedFormation} {teamValue} {sessionAddedPlayers} />
+        <div class="hidden w-full ml-2 xl:flex xl:w-1/2">
           <SimpleFixtures />
         </div>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,6 +45,7 @@ export default {
         BrandWarning: "#EFA53A",
         BrandSuccess: "#64AD54",
         BrandSlateGray: "#5A5A5A",
+        BrandRed: "#FF403C"
       },
     },
   },


### PR DESCRIPTION
-Users can now reset transfers with the newly added reset button
-New users can save team
-If a user transfers out player x for player y, then decides they don't want player y and want to bring in player z, they will no longer be subtracted two transfers and will only be subtracted one.
-updated imports to fit in with file change
Files Change:



